### PR TITLE
feat: enhance HACS configuration for commit-based installation

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
-  "name": "yahatl",
-  "render_readme": true
+  "name": "YAHATL - Yet Another Home Assistant Todo List",
+  "render_readme": true,
+  "homeassistant": "2024.1.0"
 }


### PR DESCRIPTION
- Add descriptive name to hacs.json
- Specify minimum Home Assistant version requirement
- Enable README rendering in HACS

This allows users to install the integration directly from HACS
using the latest commit without requiring tagged releases.